### PR TITLE
Allow specifying version with the V variable

### DIFF
--- a/releases
+++ b/releases
@@ -171,7 +171,7 @@ main() {
     [[ $L ]] || die "please specify user/repo as the L variable"
     [[ $L =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || die "$L: L consists of username/reponame"
     # Version of release
-    [[ ${V:+tag/$V} ]] || V=latest
+    [[ $V ]] || V=latest
 
     # Get binaries information
     local list files

--- a/releases
+++ b/releases
@@ -171,7 +171,7 @@ main() {
     [[ $L ]] || die "please specify user/repo as the L variable"
     [[ $L =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || die "$L: L consists of username/reponame"
     # Version of release
-    [[ $V ]] || V=latest
+    [[ $V ]] && [[ $V != latest ]] && V=tag/$V || V=latest
 
     # Get binaries information
     local list files

--- a/releases
+++ b/releases
@@ -170,14 +170,16 @@ main() {
     # Check L
     [[ $L ]] || die "please specify user/repo as the L variable"
     [[ $L =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || die "$L: L consists of username/reponame"
+    # Version of release
+    [[ ${V:+tag/$V} ]] || V=latest
 
     # Get binaries information
     local list files
     list=($(
     if has "curl"; then
-        curl -sSf -L https://github.com/$L/releases/latest
+        curl -sSf -L https://github.com/$L/releases/$V
     elif has "wget"; then
-        wget -qO - https://github.com/$L/releases/latest
+        wget -qO - https://github.com/$L/releases/$V
     fi 2>/dev/null \
         | grep -o '/'"$L"'/releases/download/[^"]*'
     ))

--- a/test/releases_test.sh
+++ b/test/releases_test.sh
@@ -47,9 +47,14 @@ describe "releases"
   end
 
   describe "specifying version"
-    it "downloads version 0.11.0 of junegunn/fzf-bin"
+    it "downloads release 0.11.0 of junegunn/fzf-bin"
       L=junegunn/fzf-bin V=0.11.0 main >/dev/null
       assert file_present 'fzf-0.11.0-*'
+    end
+
+    it "downloads tag jq 1.5 rc1"
+      L=stedolan/jq V=jq-1.5rc1 main >/dev/null
+      assert file_present 'jq-1.5rc1*'
     end
 
     it "fails when an invalid version is specified"

--- a/test/releases_test.sh
+++ b/test/releases_test.sh
@@ -45,4 +45,17 @@ describe "releases"
       assert equal $? $true
     end
   end
+
+  describe "specifying version"
+    it "downloads version 0.11.0 of junegunn/fzf-bin"
+      L=junegunn/fzf-bin V=0.11.0 main >/dev/null
+      assert file_present 'fzf-0.11.0-*'
+    end
+
+    it "fails when an invalid version is specified"
+      # Use subshell because this dies
+      ( L=junegunn/fzf-bin V=foobar main >/dev/null 2>&1 )
+      assert unequal $? $true
+    end
+  end
 end


### PR DESCRIPTION
I added this so that in zplug, we can do something like:

``` zsh
zplug "junegunn/fzf-bin", \
    as:command, \
    at:0.11.0, \
    from:gh-r, \
    file:fzf, \
    of:"*darwin*amd64*"
```

I wasn't sure if you were fine with adding another variable `V`. I will make the change if you prefer a different way.
