### PR TITLE
Fix bug *.tgz file save as command

### DIFF
--- a/releases
+++ b/releases
@@ -260,6 +260,7 @@ main() {
             (( "${#files[@]}" > 0 )) || die "Error: failed"
             for org in "${files[@]}"
             do
+                [[ "$org" = "${L#*/}" ]] && break
                 command mv -f "$org" "${L#*/}" 2>/dev/null && break
             done
             chmod 755 "${L#*/}" 2>/dev/null

--- a/releases
+++ b/releases
@@ -260,7 +260,7 @@ main() {
             (( "${#files[@]}" > 0 )) || die "Error: failed"
             for org in "${files[@]}"
             do
-                [[ "$org" = "${L#*/}" ]] && break
+                [[ "$org" == "${L#*/}" ]] && break
                 command mv -f "$org" "${L#*/}" 2>/dev/null && break
             done
             chmod 755 "${L#*/}" 2>/dev/null


### PR DESCRIPTION
mac works fine, but in ubuntu/centos, mv command will fail with same file name.
and, downloaded *.tgz file whill rename to target command.
it will see command broken.
it is occur in zplug manage laurent22/massren release binary.

I add break command when mv command with same name file. 
